### PR TITLE
Perpare Stoneboard for running in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 *.iml
 !.travis.yml
 !.gitignore
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:8-alpine
+
+RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && apk add --no-cache maven@edge
+
+RUN addgroup -S stoneboard \
+  && adduser -S -G stoneboard stoneboard
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN mvn clean package
+
+USER stoneboard
+EXPOSE 5000
+
+CMD java -Ddw.server.type=simple -Ddw.server.connector.type=http \
+  -Ddw.server.connector.port.port=5000 -jar target/planning.jar server \
+  ./etc/dw.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      - GITHUB_CLIENT_ID=A-GITHUB-CLIENT-ID
+      - GITHUB_CLIENT_SECRET=A-GITHUB-CLIENT-SECRET
+      - GITHUB_HOSTNAME=github.com (optional, used for GitHub Enterprise custom domains)
+      - CALLBACK_URL=https://url-to-app/auth/callback
+      - REPOSITORIES=org/repo,org/repo...


### PR DESCRIPTION
This PR adds a Dockerfile for running Stoneboard in a minimal Docker container and docker-compose.yml for convenience.
