### PR TITLE
Document rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This tells us the milestone has two dependencies; milestone 2 and 3 in the repo 
 
 ![example](stoneboard-example.png)
 
+## Rationale
+
+The underlying reasoning behind this style of task visualisation and planning is partly described in the presentation _"[Bastardised Kanban](https://speakerdeck.com/chids/bastardised-kanban)"_ from 2015.
+
 ## Local development
 
 ### Prerequisites


### PR DESCRIPTION
AFAIK the presentation is the only publicly available documentation for the underlying rationale, so might make sense to link to it.