### PR TITLE
Make POM more portable

### DIFF
--- a/.github/workflows/maven-master-deploy.yml
+++ b/.github/workflows/maven-master-deploy.yml
@@ -1,4 +1,6 @@
 name: Build and deploy docker image
+env:
+  PACKAGE: stoneboard
 on:
   push:
     branches: [ master ]
@@ -17,11 +19,13 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Build and test
+        run: mvn verify
       - name: Publish image
-        run: mvn compile jib:build
+        run: mvn jib:build -Djib.to.image=docker.pkg.github.com/${GITHUB_REPOSITORY}/${PACKAGE} -Djib.to.auth.username=${GITHUB_ACTOR} -Djib.to.auth.password=${GITHUB_TOKEN} -Djib.to.image.tags=latest -Djib.to.image.tags=${GITHUB_SHA}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Purge oldest image
         uses: actions/delete-package-versions@v1
         with:
-          package-name: 'stoneboard'
+          package-name: ${{env.PACKAGE}}

--- a/pom.xml
+++ b/pom.xml
@@ -49,18 +49,6 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>2.2.0</version>
-        <configuration>
-          <to>
-            <image>docker.pkg.github.com/${env.GITHUB_REPOSITORY}/${project.artifactId}:latest</image>
-            <auth>
-              <username>${env.GITHUB_ACTOR}</username>
-              <password>${env.GITHUB_TOKEN}</password>
-            </auth>
-            <tags>
-              <tag>${env.GITHUB_SHA}</tag>
-            </tags>
-          </to>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Move Jib config from POM to GH Action
- Separate build and test from Dockerization